### PR TITLE
Include Localization.strings in the CocoaPods bundle

### DIFF
--- a/DexcareSDK.podspec
+++ b/DexcareSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/DexcareiOSSDK/**/*.swift'
   s.resource_bundles = {
-    'DexcareSDK' => ['Sources/DexcareiOSSDK/**/*.{xib,storyboard,xcassets}']
+    'DexcareSDK' => ['Sources/DexcareiOSSDK/**/*.{xib,storyboard,xcassets,strings}']
   }
 
   # DexcareSDK dependency


### PR DESCRIPTION
added pattern to include strings files so it will pull Localizable.strings into the pod bundle